### PR TITLE
Use StoryBook panel's active prop to render panels only when active

### DIFF
--- a/src/lib/components/HistoryPanel.js
+++ b/src/lib/components/HistoryPanel.js
@@ -11,7 +11,8 @@ import * as types from '../actionTypes'
 
 const mapSateChange = (change, i) => <StateChange {...change} key={change.id} />
 
-export const HistoryPanel = ({ changes, enabled, actionFilter, diffFilter, onDiffFilter, onActionFilter, changeIsVisible, reset }) => {
+export const HistoryPanel = ({ changes, enabled, active, actionFilter, diffFilter, onDiffFilter, onActionFilter, changeIsVisible, reset }) => {
+  if (!active) return null
   if (!enabled) return <div className='addon-redux-disabled'>withRedux Not Enabled</div>
   return (
     <table className='addon-redux addon-redux-history-panel'>
@@ -35,6 +36,7 @@ export const HistoryPanel = ({ changes, enabled, actionFilter, diffFilter, onDif
 HistoryPanel.propTypes = {
   changes: PropTypes.array.isRequired,
   enabled: PropTypes.bool.isRequired,
+  active: PropTypes.bool.isRequired,
   actionFilter: PropTypes.string.isRequired,
   diffFilter: PropTypes.string.isRequired,
   onDiffFilter: PropTypes.func.isRequired,

--- a/src/lib/components/StatePanel.js
+++ b/src/lib/components/StatePanel.js
@@ -9,6 +9,7 @@ import * as events from '../events'
 import SetStateForm from './SetStateForm'
 
 export const StatePanel = props => {
+  if (!props.active) return null
   if (!props.enabled) return <div className='addon-redux-disabled'>withRedux Not Enabled</div>
   return (
     <div className='addon-redux'>
@@ -19,6 +20,7 @@ export const StatePanel = props => {
 
 StatePanel.propTypes = {
   enabled: PropTypes.bool.isRequired,
+  active: PropTypes.bool.isRequired,
   state: PropTypes.object.isRequired,
   channel: PropTypes.object.isRequired,
   api: PropTypes.object.isRequired,

--- a/src/register.js
+++ b/src/register.js
@@ -10,12 +10,12 @@ export default addons => {
 
     addons.addPanel('storybook/with_redux/state', {
       title: 'Redux State',
-      render: () => <StatePanel {...apiProps} />
+      render: ({ active }) => <StatePanel {...apiProps} active={active} />
     })
 
     addons.addPanel('storybook/with_redux/history', {
       title: 'Redux History',
-      render: () => <HistoryPanel {...apiProps} />
+      render: ({ active }) => <HistoryPanel {...apiProps} active={active} />
     })
   })
 }


### PR DESCRIPTION
This plugin doesn't work well with Storybook 4 — both panels always show regardless of which storybook panel is open. This patches that behaviour for Storybook 4 users.

+ Implemented Storybook 4 `active` prop for plugin panels