### PR TITLE
Add prepublishOnly to build package before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/frodare/addon-redux.git"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build": "babel ./src -d ./",
     "dev": "babel ./src -d ./ -w"
   },


### PR DESCRIPTION
It looks like that last release `0.1.3` didn't get the updated package build files. Have added a [prepublishOnly](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare) script to ensure the package is built during `npm publish`.