### PR TITLE
Support asynchronous loading of store

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,15 @@
-const store = require('../stories/store').default
 
 module.exports = {
-  decorators: []
+  decorators: [],
+  loaders: [
+    async () => ({
+      ready: 
+        // need to import store here so that addon-redux can detect it
+        await import('../stories/store')
+        .then(() => {
+          console.log('Store initialized');
+          return true;
+        }),
+    }),
+  ]
 };

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ export default store
 The store must be imported in `./storybook/preivew.js` so that it will be setup and ready for the stories. 
 This addon will automatically wrap stories with the Redux provider as long as the enhancer has been setup as shown above.
 
+This can be done in two ways:
+
+1. Import the store at the top of your file synchronously
+
 ```js
 // .storybook/preview.js
 const store = require('./your/store')
@@ -120,6 +124,23 @@ const store = require('./your/store')
 module.exports = {
   decorators: []
 }
+```
+
+2. Import the store asynchronously using [Storybook loaders](https://storybook.js.org/docs/react/writing-stories/loaders)
+
+```js
+// .storybook/preview.js
+
+module.exports = {
+  decorators: [],
+  loaders: [
+    async () => ({
+      // need to import store here so that addon-redux can detect it
+      store: await import('../stories/store'),
+    }),
+  ]
+};
+
 ```
 
 ![Redux Addon History Panel](docs/v2/addon-redux-history-panel.png?v=1)

--- a/src/components/StateView.tsx
+++ b/src/components/StateView.tsx
@@ -6,23 +6,49 @@ import { useAddonState, useChannel } from '@storybook/api'
 import useSyncReduxArgs from '../util/useSyncReduxArgs'
 import useSetStateFromParameter from '../util/useSetStateFromParameter'
 import { parse } from '../util/jsonHelper'
+import { STORY_CHANGED } from '@storybook/core-events'
+import { AnyAction } from 'redux'
 
-const StateView: FC<{}> = () => {
+const StateViewContainer: FC<{}> = () => {
   const [state, setState] = useAddonState<State>(STATE_ID_STORE)
 
-  useSetStateFromParameter()
-  useSyncReduxArgs(state)
+  /*
+   * We need to wait until after addon-redux is initialized
+   * Otherwise, we will receive the story args before the store is created
+   * If the store is loaded asynchronously
+   */
+  const [initialized, setInitialized] = React.useState<boolean>(false)
 
   const emit = useChannel({
     [EVENTS.ON_DISPATCH]: (ev: OnDispatchEvent) => setState(parse(ev.state)),
-    [EVENTS.INIT]: (ev: OnInitEvent) => setState(parse(ev.state))
+    [EVENTS.INIT]: (ev: OnInitEvent) => {
+      setInitialized(true)
+      return setState(parse(ev.state))
+    },
+    [STORY_CHANGED]: (_action: AnyAction) => {
+      setInitialized(false)
+    }
   })
 
-  const onChange: ChangeHandler = value => {
-    emit(EVENTS.SET_STATE, JSON.stringify(value))
-  }
+  const onChange: ChangeHandler = React.useCallback(
+    value => {
+      emit(EVENTS.SET_STATE, JSON.stringify(value))
+    },
+    []
+  )
 
-  return <ObjectEditor value={state} onChange={onChange} />
+  if (!initialized) {
+    return <>Loading...</>
+  } else {
+    return <StateView state={state} onChange={onChange} />
+  }
 }
 
-export default StateView
+const StateView: FC<{ state: any, onChange: (value: any) => void }> = (args) => {
+  useSetStateFromParameter()
+  useSyncReduxArgs(args.state)
+
+  return <ObjectEditor value={args.state} onChange={args.onChange} />
+}
+
+export default StateViewContainer

--- a/src/redux/enhancer.ts
+++ b/src/redux/enhancer.ts
@@ -43,9 +43,10 @@ const enhancer: StoreEnhancer<any> = (createStore: StoreEnhancerStoreCreator) =>
 
   const enhanceDispatch: Enhancer<Dispatcher> = dispatch => action => {
     const prev = store.getState()
-    dispatch(action)
+    const result = dispatch(action)
     const next = store.getState()
     if (listener !== null) listener(action, prev, next)
+    return result
   }
 
   let listener: StoreListener = null

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from './Button'
-import { PARAM_REDUX_MERGE_STATE, ARG_REDUX_PATH, ARG_REDUX_SET_STATE } from '../dist/esm'
+import { PARAM_REDUX_MERGE_STATE, ARG_REDUX_PATH, ARG_REDUX_SET_STATE } from '../src/constants'
 
 export default {
   title: 'Example/Button',


### PR DESCRIPTION
Currently if you need to asynchronously load the store (because some other library needs to be loaded first, etc.), addon-redux will not catch the initial injects args in the story.

I fixed this by having that addon-redux only starts scanning for props after the `INIT` message was sent. This worked for the tests in this repo and also a project my company is working on, but there could be some edge cases I'm missing

I also took the opportunity to fix #30 in the same PR (But feel free to make the fix as a separate PR)