### PR TITLE
Fix keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Storybook addon for Redux Components",
   "author": "Charles Howard",
   "keywords": [
+    "storybook-addon",
+    "data-state",
     "storybook",
-    "storybook-addons",
     "redux",
     "react",
-    "data-state"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed this addon wasn't showing up in the addon list on the Storybook website

I noticed the documentation for publishing an addon lists the following:

> We rely on metadata to organize your addon in the catalog.
> You must add the storybook-addons as the **first** keyword, **followed by** your addon's category. Additional keywords will be used in search and as tags.

However, the keywords in the package.json are not in the right order. Possibly fixing the order will get the package to show up properly?