### PR TITLE
Added guard for undefined global module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-if ((module?.hot?.decline) != null) {
+if (typeof module !== 'undefined' && (module?.hot?.decline) != null) {
   module.hot.decline()
 }
 


### PR DESCRIPTION
This PR fixes `Uncaught ReferenceError: module is not defined` in bundlers such as `vite`. I know the project has not been maintained for 2 years but maybe it'll help anyone with the problem

Similar issue to https://github.com/redux-form/redux-form/pull/4723 with almost the same fix